### PR TITLE
Fix/styling conflicts #BOT-275

### DIFF
--- a/booking-platform/src/webchat/cover-component.js
+++ b/booking-platform/src/webchat/cover-component.js
@@ -5,8 +5,7 @@ import { emailRegex, MyTextField } from '../utils'
 
 const Container = styled.div`
   position: absolute;
-  height: 432px;
-  width: calc(100%-60px);
+  height: calc(100% - 48px);
   left: 0;
   top: 48px;
   background: white;
@@ -22,7 +21,7 @@ const Button = styled.button`
   height: 40px;
   background: #2f2f2f;
   border-radius: 8px;
-  margin-top: 20px;
+  margin: 20px;
   text-align: center;
   color: white;
 `

--- a/booking-platform/src/webchat/custom-button.js
+++ b/booking-platform/src/webchat/custom-button.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 const StyledButton = styled.div`
@@ -11,19 +11,14 @@ const StyledButton = styled.div`
   color: black;
   text-align: center;
   white-space: normal;
+  &:hover {
+    opacity: 0.5;
+  }
 `
 
 export const CustomButton = (props) => {
-  let [hover, setHover] = useState(false)
-
   return (
-    <StyledButton
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-      style={{
-        opacity: hover ? '0.5' : '1',
-      }}
-    >
+    <StyledButton>
       {props.children}
     </StyledButton>
   )

--- a/booking-platform/src/webchat/custom-header.js
+++ b/booking-platform/src/webchat/custom-header.js
@@ -6,7 +6,6 @@ import Comment from '../assets/comment.svg'
 import { staticAsset } from '@botonic/react'
 
 const Header = styled.div`
-  cursor: pointer;
   height: 48px;
   background: #495e86;
   z-index: 2;
@@ -20,6 +19,7 @@ const Title = styled.h1`
   line-height: 1px;
   color: #ffffff;
   width: 80%;
+  margin: 0;
 `
 
 export const CustomHeader = () => {

--- a/booking-platform/src/webchat/custom-persistentMenu-button.js
+++ b/booking-platform/src/webchat/custom-persistentMenu-button.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from 'react'
+import React, { useContext } from 'react'
 import styled from 'styled-components'
 import { WebchatContext } from '@botonic/react'
 import { IconContainer } from './common'
@@ -11,6 +11,9 @@ const StyledButton = styled.div`
   display: flex;
   justify-content: left;
   align-items: center;
+  &:hover {
+    opacity: 0.5;
+  }
 `
 
 const Text = styled.p`
@@ -18,10 +21,10 @@ const Text = styled.p`
   font-weight: 400;
   color: #000000;
   text-align: left;
+  margin: 0;
 `
 
 export const CustomMenuButton = (props) => {
-  let [hover, setHover] = useState(false)
   const { sendInput, openWebview } = useContext(WebchatContext)
 
   const handleClick = (event) => {
@@ -38,11 +41,6 @@ export const CustomMenuButton = (props) => {
   return (
     <StyledButton
       onClick={(e) => handleClick(e)}
-      onMouseEnter={() => setHover(true)}
-      onMouseLeave={() => setHover(false)}
-      style={{
-        opacity: hover ? '0.5' : '1',
-      }}
     >
       <IconContainer>
         <img

--- a/booking-platform/src/webchat/hotel-form-message.js
+++ b/booking-platform/src/webchat/hotel-form-message.js
@@ -98,7 +98,7 @@ class HotelForm extends React.Component {
     ]
     return (
       <Form>
-        <p style={{ fontSize: 10 }}>
+        <p style={{ fontSize: 10, marginBottom: '5px' }}>
           <em>
             We will not store the fulfilled information. You can fake the data.
           </em>
@@ -121,7 +121,7 @@ class HotelForm extends React.Component {
           }}
           style={{
             width: '100%',
-            padding: '0px 0px 5px 63px',
+            margin: '0px -63px 5px 0px',
           }}
           renderInput={params => (
             <MyTextField

--- a/booking-platform/src/webchat/index.js
+++ b/booking-platform/src/webchat/index.js
@@ -29,6 +29,7 @@ export const webchat = {
       boxShadow: '0 0 50px #C1CED7',
       overflow: 'hidden',
       fontFamily: 'Arial',
+      lineHeight: 1.3,
     },
 
     message: {

--- a/nlu-assistant/src/webchat/index.js
+++ b/nlu-assistant/src/webchat/index.js
@@ -8,6 +8,7 @@ import { PRIMARY_COLOR } from './constants'
 export const webchat = {
   storage: sessionStorage,
   storageKey: 'botonic-nlu-example',
+  shadowDOM: true,
 
   onInit: app => {
     app.clearMessages()

--- a/telco-offers/src/webchat/index.js
+++ b/telco-offers/src/webchat/index.js
@@ -6,6 +6,7 @@ import { COLORS } from './constants'
 export const webchat = {
   storage: sessionStorage,
   storageKey: 'botonic-telco-example',
+  shadowDOM: true,
 
   onOpen: app => {
     app.clearMessages()
@@ -19,6 +20,7 @@ export const webchat = {
       width: 370,
       borderRadius: 10,
       background: '#F5F5F5',
+      lineHeight: 1.3,
     },
     header: {
       image: BotIconWhite,


### PR DESCRIPTION
<!-- _Set as [Draft PR](https://github.blog/2019-02-14-introducing-draft-pull-requests/) if it's not ready to be merged_.

[PR best practices Reference](https://blog.codeminer42.com/on-writing-a-great-pull-request-37c60ce6f31d/) -->

## Description

Fix styling conflicts between injected webchats and docusaurus

## Approach taken / Explain the design

- The conflicts in the `nlp assistant` and the `telco offers` examples are solved using the `shadowDom`.
- The conflicts in the `booking-platform` example are solved changing some styles. The `shadowDom` didn't work because it breaks the styles of the material-ui library.
## To document / Usage example


## Testing

The pull request...

- has unit tests
- has integration tests
- doesn't need tests because... **[provide a description]**
